### PR TITLE
Added sprint crouch to medic (read desc.)

### DIFF
--- a/Content/Game_BP/Character/CH_Character_Medic.uasset
+++ b/Content/Game_BP/Character/CH_Character_Medic.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ace100ff1dd7b291e342756978cc84b2d1c5d1234f15870da2837011ab56a269
-size 46304
+oid sha256:acf5928e94d5a7200f1167f937c08d456623c79aa40e61d4ebac7955514d7be4
+size 109615


### PR DESCRIPTION
Ch p new crouch sprint dr
I was able to add the extra movement to the medic class only. The base class for the default character didn't allow me to use keyboard events or input actions. Even copying and pasting would not bring over the necessary nodes.