### PR TITLE
Merging Code Sublevels Updates into Env_Code

### DIFF
--- a/Content/Developers/danie/Collections/Levels/LVL1_Test.umap
+++ b/Content/Developers/danie/Collections/Levels/LVL1_Test.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:06d01d39fd0aa17e26991e5475524edae2cf0eaf00d75da6031a0db5c5706bc9
-size 108449
+oid sha256:ffdf62039b6fffcb8569be92e9177ee5c6d0ec7df5b9ac4c8150a46cf1bcf367
+size 125198

--- a/Content/Game_BP/Items/BP_Payload.uasset
+++ b/Content/Game_BP/Items/BP_Payload.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e92b006cb83b894ceca79b89b7b04a9bc4a79b95f48ace474408fa16f04273a1
-size 273916
+oid sha256:1dd50bc75b7f65d61649347b332692dd5d5ccae0076e133be9435435575f88da
+size 272606

--- a/Content/Game_BP/Placeables/BP_DestructibleCrate.uasset
+++ b/Content/Game_BP/Placeables/BP_DestructibleCrate.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a264923af612d645ccf65f9d44d9ed7d21c69f25698864b26161976e781d97a3
-size 150497
+oid sha256:c79e09a1d4d90c1215431fa404c82a5384f445bc56ad7d7e88dcb123357a1caa
+size 153340

--- a/Content/Game_BP/Placeables/BP_Workbench.uasset
+++ b/Content/Game_BP/Placeables/BP_Workbench.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3a3b68cb8a21f15b198700467d5a8694e9322aa9d4ac0a0f9f6ef9c7f8427173
-size 325945
+oid sha256:80d33f5c162b5c015b96c946780f6ea58f5b31b7bba22b47d643da430677bbff
+size 327073

--- a/Content/Game_BP/Placeables/PayloadRespawn/BP_PayloadInitialLocation.uasset
+++ b/Content/Game_BP/Placeables/PayloadRespawn/BP_PayloadInitialLocation.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6fcea5d011b1ab3b285dc0e98c4340736395945d7899765dd964fb132eafaa82
+size 63918

--- a/Content/Game_BP/Placeables/PayloadRespawn/BP_PayloadOutOfBoundsVolume.uasset
+++ b/Content/Game_BP/Placeables/PayloadRespawn/BP_PayloadOutOfBoundsVolume.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d624dea39130ccf054968006d74ee5b6ce696e0b0322b6a897d18440eb87f81
+size 42145

--- a/Content/Levels/Level1/L_TheQuarry_Code_01.umap
+++ b/Content/Levels/Level1/L_TheQuarry_Code_01.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fb16dbd8ad6fb87865ef0848ee087a69ba7f3819bef2ee46d69544fe18c9fa9a
-size 949327
+oid sha256:bf52c7b72365ee2d637274058c40e8e48dc71d74e0db2094251ee3227b72c5d4
+size 1069345

--- a/Content/Levels/Level1/ML_Level1.umap
+++ b/Content/Levels/Level1/ML_Level1.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7ff4ccff2ef3257ce68d60c7d7991f9e193000129cc69af9bc1b6563fa759f0b
+oid sha256:ab35377530a7ae1fc651d6dbc1c2ecf9f446f0e1772d767049b884f3fadb9378
 size 37990

--- a/Content/Levels/Level2/L_NuclearWasteland_Code_01.umap
+++ b/Content/Levels/Level2/L_NuclearWasteland_Code_01.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d6f799dc59e1f4a322fb0759e94475ce43805a7f9b5e4ce8f5d127053598b2fe
-size 1470293
+oid sha256:871c404a6eab4aa8862a42b88637fb55e255c4077087b7bde60fa5c2ad0a2ffc
+size 1517545

--- a/Content/Levels/Level2/ML_Level2.umap
+++ b/Content/Levels/Level2/ML_Level2.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e19be005f4d07c9f6cb13e25b77255e4238771a5262eeba5412ccbf9caafc7f0
+oid sha256:1b8f6a8948db77d2af3340872b0f850628dce14004503acfe967bc309b7125a5
 size 126200


### PR DESCRIPTION
*-repositioned flare in the Quarry lvl (code)
*-rebuilt paths for AI navigation in the Quarry lvl (master) 
*-added enemy spawners in the mines of the Quarry lvl (code) 
*-repositioned turret in the Nuclear Wasteland lvl (master) 
*-unchecked "Can Ever Affect Navigation" option for firewalls in the Nuclear Wasteland lvl (code) 
*-deleted a few lingering CH_CharacterBase instances in the Nuclear Wasteland lvl (code) since we have spawners now 
*-deleted navlinks by the ramp in the mines of the Quarry lvl (code) 
*-changed collision to ignore player, pawn and enemy for the destructible crates 
*-placed destructible crates in the Quarry (code) and Nuclear Wasteland (code) lvls 
+-added a BP to get the payload's initial location (or can be set to wherever in the map to respawn) 
+-added a BP for the payload to be 'out of bounds' (e.g. the lake in the Nuclear Wasteland)